### PR TITLE
feat: update secp256k1 library to v5.0.0

### DIFF
--- a/index.js
+++ b/index.js
@@ -127,10 +127,10 @@ function sign (
   const hash = magicHash(message, messagePrefixArg)
   const sigObj = isSigner(privateKey)
     ? privateKey.sign(hash, extraEntropy)
-    : secp256k1.sign(hash, privateKey, { data: extraEntropy })
+    : secp256k1.ecdsaSign(hash, privateKey, { data: extraEntropy })
   return encodeSignature(
     sigObj.signature,
-    sigObj.recovery,
+    sigObj.recid,
     compressed,
     segwitType
   )
@@ -153,11 +153,11 @@ function signAsync (
     const hash = magicHash(message, messagePrefixArg)
     return isSigner(privateKey)
       ? privateKey.sign(hash, extraEntropy)
-      : secp256k1.sign(hash, privateKey, { data: extraEntropy })
+      : secp256k1.ecdsaSign(hash, privateKey, { data: extraEntropy })
   }).then((sigObj) => {
     return encodeSignature(
       sigObj.signature,
-      sigObj.recovery,
+      sigObj.recid,
       compressed,
       segwitType
     )
@@ -188,12 +188,13 @@ function verify (message, address, signature, messagePrefix, checkSegwitAlways) 
   }
 
   const hash = magicHash(message, messagePrefix)
-  const publicKey = secp256k1.recover(
-    hash,
+  const publicKey = secp256k1.ecdsaRecover(
     parsed.signature,
     parsed.recovery,
+    hash,
     parsed.compressed
   )
+
   const publicKeyHash = hash160(publicKey)
   let actual, expected
 

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "bs58check": "^2.1.2",
     "buffer-equals": "^1.0.3",
     "create-hash": "^1.1.2",
-    "secp256k1": "^3.0.1",
+    "secp256k1": "5.0.0",
     "varuint-bitcoin": "^1.0.1"
   },
   "devDependencies": {

--- a/test/index.js
+++ b/test/index.js
@@ -27,8 +27,8 @@ fixtures.valid.magicHash.forEach(f => {
 fixtures.valid.sign.forEach(f => {
   test('sign: ' + f.description, async t => {
     const pk = new bitcoin.ECPair(new BigInteger(f.d)).d.toBuffer(32)
-    const signer = (hash, ex) => secp256k1.sign(hash, pk, { data: ex })
-    const signerAsync = async (hash, ex) => secp256k1.sign(hash, pk, { data: ex })
+    const signer = (hash, ex) => secp256k1.ecdsaSign(hash, pk, { data: ex })
+    const signerAsync = async (hash, ex) => secp256k1.ecdsaSign(hash, pk, { data: ex })
     let signature = message.sign(
       f.message,
       pk,


### PR DESCRIPTION
As part of this update there had to be minor changes to the secp256k1 library callsites. sign was changed to ecdsaSign and recover was changed to ecdsaRecover including reordering of params.

Ticket: BTC-421

```
➜ npm run unit                                  

> bitcoinjs-message@2.2.0 unit
> tape test/*.js

TAP version 13
# produces the magicHash for "" (bitcoin)
ok 1 should be equivalent
# produces the magicHash for "Vires is Numeris" (bitcoin)
ok 2 should be equivalent
# produces the magicHash for "Virès is Numéris" (bitcoin)
ok 3 should be equivalent
# produces the magicHash for "Vires is Numeris" (dogecoin)
ok 4 should be equivalent
# produces the magicHash for "Virès is Numéris" (dogecoin)
ok 5 should be equivalent
# sign: gives equal r, s values irrespective of point compression or segwit type
ok 6 should be equivalent
ok 7 should be equivalent
ok 8 should be equivalent
ok 9 should be equivalent
ok 10 should be equivalent
ok 11 should be equivalent
ok 12 should be equivalent
ok 13 should be equivalent
# sign: supports alternative networks
ok 14 should be equivalent
ok 15 should be equivalent
ok 16 should be equivalent
ok 17 should be equivalent
ok 18 should be equivalent
# verifies a valid signature for "vires is numeris" (bitcoin)
ok 19 should be truthy
ok 20 should be truthy
ok 21 should be truthy
ok 22 should be truthy
ok 23 should be truthy
ok 24 should be truthy
ok 25 should be truthy
# verifies a valid signature for "vires is numeris" (dogecoin)
ok 26 should be truthy
# decode signature: throws on 2b987ceade6a304fc5823ab38f99fc3c5f772a2d3e89ea05931e2726105fc53b9e601fc3231f35962c714fcbce5c95b427496edc7ae8b3d12e93791d7629795b62
ok 27 should throw
# decode signature: throws on 1c987ceade6a304fc5823ab38f99fc3c5f772a2d3e89ea05931e2726105fc53b9e601fc3231f35962c714fcbce5c95b427496edc7ae8b3d12e93791d7629795b62000000
ok 28 should throw
# decode signature: throws on 1c987ceade6a304fc5823ab38f99fc3c5f772a2d3e89ea05931e2726105fc53b9e601fc3231f35962c714fcbce5c95b427496edc7ae8b3d12e9379
ok 29 should throw
# will fail for the wrong message
ok 30 should be falsy
# will fail for the wrong address
ok 31 should be falsy
# does not cross verify (uncompressed address, compressed signature)
ok 32 should be falsy
# does not cross verify (compressed address, uncompressed signature)
ok 33 should be falsy
# check that signatures extra data argument is passed correctly
ok 34 should be truthy
ok 35 should be truthy
# Check that compressed signatures can be verified as segwit
ok 36 should be truthy
ok 37 should be truthy
ok 38 should be truthy
ok 39 should be truthy
ok 40 should be truthy
ok 41 should throw
ok 42 should throw
# Check that invalid segwitType fails
ok 43 should throw
# Check that Buffers and wrapped Strings are accepted
ok 44 should be equal

1..44
# tests 44
# pass  44

# ok


```