### PR TITLE
chore: remove @BitGo/velocity from code-owners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,6 +1,6 @@
 # github actions
-.github                                             @BitGo/btc-team @BitGo/infra @BitGo/velocity
-renovate.json                                       @BitGo/btc-team @BitGo/infra @BitGo/velocity
+.github                                             @BitGo/btc-team @BitGo/infra
+renovate.json                                       @BitGo/btc-team @BitGo/infra
 
 ## THIS SHOULD ALWAYS BE LAST ##
 * @BitGo/btc-team


### PR DESCRIPTION
Velocity does not own this repository or any of the files in it, so this
code-owners change cuts down on noise for the Velocity review team.